### PR TITLE
fix: remove unexpected settings

### DIFF
--- a/ftplugin/bib.vim
+++ b/ftplugin/bib.vim
@@ -8,7 +8,7 @@ augroup END
 if executable('bibtex-tidy')
   autocmd vimrcFileTypeBib BufWinEnter <buffer> ++once let &l:formatprg = 'bibtex-tidy --quiet ' .
         \ ' --merge combine --strip-enclosing-braces --drop-all-caps --encode-urls --trailing-commas --tidy-comments --remove-empty-fields --sort ' .
-        \ ' --wrap=' . &textwidth .
+        \ (&textwidth > 0 ? ' --wrap=' . &textwidth : '') .
         \ ' --blank-lines --space=' . &shiftwidth . ' ' . (&expandtab ? '--no-tab' : '--tab')
 elseif executable('prettybib.py')
   setlocal formatprg=prettybib.py

--- a/ftplugin/c.vim
+++ b/ftplugin/c.vim
@@ -5,17 +5,17 @@ augroup vimrcFileTypeC
   endif
 augroup END
 
-setlocal textwidth=80
+
 
 if executable('uncrustify')
   autocmd vimrcFileTypeC BufWinEnter <buffer> ++once let &l:formatprg = 'uncrustify -q -l CPP ' .
-        \ ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth .
+        \ (&textwidth > 0 ? ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth : '') .
         \ ' --set indent_columns=' . &shiftwidth . (&expandtab ? ' --set indent_with_tabs=0' : '') .
         \ (filereadable(expand('%')) ? ' --assume %:S' : '')
 elseif executable('astyle')
   autocmd vimrcFileTypeC BufWinEnter <buffer> ++once let &l:formatprg='astyle --mode=c --style=google ' .
               \ ' --pad-oper --pad-header --unpad-paren --align-pointer=name --align-reference=name --add-brackets --suffix=none ' .
-              \ ' --max-code-length=' . &textwidth .
+              \ (&textwidth > 0 ? ' --max-code-length=' . &textwidth : '') .
               \ ' --indent=spaces=' . &shiftwidth . (&expandtab ? ' --convert-tabs' : '')
 elseif executable('clang-format')
   let &l:formatprg = 'clang-format --assume-filename=%:S --style=Google'

--- a/ftplugin/cmake.vim
+++ b/ftplugin/cmake.vim
@@ -5,13 +5,10 @@ augroup vimrcFileTypeCMake
   endif
 augroup END
 
-setlocal foldmethod=indent
-
-setlocal textwidth=80
 if executable('cmake-format')
   autocmd vimrcFileTypeCMake BufWinEnter <buffer> ++once
         \ let &l:formatprg='cmake-format'
-        \ . ' --line-width=' . &textwidth . ' --tab-size=' . &shiftwidth . (&expandtab ? '' : ' --use-tabchars')
+        \ . (&textwidth > 0 ? ' --line-width=' . &textwidth : '') . ' --tab-size=' . &shiftwidth . (&expandtab ? '' : ' --use-tabchars')
         \ . ' -'
 elseif executable('neocmakelsp')
   setlocal formatprg=neocmakelsp\ format

--- a/ftplugin/cpp.vim
+++ b/ftplugin/cpp.vim
@@ -5,17 +5,15 @@ augroup vimrcFileTypeC
   endif
 augroup END
 
-setlocal textwidth=80
-
 if executable('uncrustify')
   autocmd vimrcFileTypeC BufWinEnter <buffer> ++once let &l:formatprg = 'uncrustify -q -l CPP ' .
-        \ ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth .
+        \ (&textwidth > 0 ? ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth : '') .
         \ ' --set indent_columns=' . &shiftwidth . (&expandtab ? ' --set indent_with_tabs=0' : '') .
         \ (filereadable(expand('%')) ? ' --assume %:S' : '')
 elseif executable('astyle')
   autocmd vimrcFileTypeC BufWinEnter <buffer> ++once let &l:formatprg='astyle --mode=c --style=google ' .
               \ ' --pad-oper --pad-header --unpad-paren --align-pointer=name --align-reference=name --add-brackets --suffix=none ' .
-              \ ' --max-code-length=' . &textwidth .
+              \ (&textwidth > 0 ? ' --max-code-length=' . &textwidth : '') .
               \ ' --indent=spaces=' . &shiftwidth . (&expandtab ? ' --convert-tabs' : '')
 elseif executable('clang-format')
   let &l:formatprg = 'clang-format --assume-filename=%:S --style=Google'

--- a/ftplugin/java.vim
+++ b/ftplugin/java.vim
@@ -5,15 +5,14 @@ augroup vimrcFileTypeJava
   endif
 augroup END
 
-setlocal textwidth=80
 if executable('uncrustify')
   autocmd vimrcFileTypeJava BufWinEnter <buffer> ++once let &l:formatprg = 'uncrustify -q -l JAVA ' .
-        \ ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth .
+        \ (&textwidth > 0 ? ' --set code_width=' . &textwidth . ' --set cmt_width=' . &textwidth : '') .
         \ ' --set indent_columns=' . &shiftwidth . (&expandtab ? ' --set indent_with_tabs=0' : '') .
         \ (filereadable(expand('%')) ? ' --assume %:S' : '')
 elseif executable('astyle')
   autocmd vimrcFileTypeJava BufWinEnter <buffer> ++once let &l:formatprg='astyle --mode=java --style=java ' .
               \ ' --pad-oper --pad-header --unpad-paren --align-pointer=name --align-reference=name --add-brackets --suffix=none ' .
-              \ ' --max-code-length=' . &textwidth .
+              \ (&textwidth > 0 ? ' --max-code-length=' . &textwidth : '') .
               \ ' --indent=spaces=' . &shiftwidth . (&expandtab ? ' --convert-tabs' : '')
 endif

--- a/ftplugin/javascript.vim
+++ b/ftplugin/javascript.vim
@@ -1,6 +1,5 @@
 if &filetype !=# 'javascript' | finish | endif
 
-setlocal textwidth=80
 if executable('prettier')
   augroup vimrcFileTypeJavaScript
     autocmd! * <buffer>
@@ -9,7 +8,7 @@ if executable('prettier')
     endif
     autocmd BufWinEnter <buffer> ++once let &l:formatprg =
                 \ 'prettier --stdin-filepath=%:S --parser=javascript --single-quote' .
-                \ ' --print-width=' . &textwidth .
+                \ (&textwidth > 0 ? ' --print-width=' . &textwidth : '') .
                 \ ' --tab-width=' . &l:shiftwidth . (&expandtab ? '' : '--use-tabs') . ' --'
   augroup END
 endif

--- a/ftplugin/lua.vim
+++ b/ftplugin/lua.vim
@@ -5,7 +5,6 @@ augroup vimrcFileTypeLua
   endif
 augroup END
 
-setlocal textwidth=80
 if executable('stylua')
   autocmd vimrcFileTypeLua BufWinEnter <buffer> ++once let &l:formatprg = 'stylua ' .
         \ ' --column-width ' . &l:textwidth .
@@ -15,7 +14,7 @@ if executable('stylua')
 elseif executable('prettier')
   autocmd vimrcFileTypeLua BufWinEnter <buffer> ++once let &l:formatprg =
         \ 'prettier --stdin-filepath=%:S --parser=lua --single-quote' .
-        \ ' --print-width=' . &textwidth .
+        \ (&textwidth > 0 ? ' --print-width=' . &textwidth : '') .
         \ ' --tab-width=' . &l:shiftwidth . (&expandtab ? '' : '--use-tabs') . ' --'
 endif
 

--- a/ftplugin/mail.vim
+++ b/ftplugin/mail.vim
@@ -5,9 +5,6 @@ augroup vimrcFileTypeMail
   endif
 augroup END
 
-" RFC 1855 suggests 65 because of the preceding angle brackets
-setlocal textwidth=80
-
 " see https://stackoverflow.com/questions/21413120/how-can-i-get-gg-g-in-vim-to-ignore-a-comma/21413701#21413701
 setlocal cinoptions+=+0
 

--- a/ftplugin/sh.vim
+++ b/ftplugin/sh.vim
@@ -1,4 +1,4 @@
-setlocal textwidth=80
+
 
 if executable('shfmt')
   if exists('##ShellFilterPost')

--- a/ftplugin/zsh.vim
+++ b/ftplugin/zsh.vim
@@ -1,9 +1,3 @@
-setlocal textwidth=80
-setlocal shiftwidth=2
-setlocal tabstop=2
-setlocal softtabstop=2
-setlocal expandtab
-
 if executable('shfmt')
   augroup vimrcFileTypeZsh
     autocmd! * <buffer>
@@ -11,7 +5,7 @@ if executable('shfmt')
       autocmd ShellFilterPost <buffer> if v:shell_error | execute 'echom "shell filter returned error " . v:shell_error . ", undoing changes"' | undo | endif
     endif
     autocmd BufWinEnter <buffer> ++once let &l:formatprg =
-          \ 'shfmt -ln posix -sr -ci -s -i ' . &l:shiftwidth
+          \ 'shfmt --language-dialect posix --space-redirects --case-indent --simplify --indent ' . (&expandtab > 0 ? &shiftwidth : 0)
   augroup END
 endif
 if executable('format_shell_cmd.py')


### PR DESCRIPTION
I've not tested this; in particular, it's very possible that things might break when `&textwidth` is set to 0 (default).

